### PR TITLE
Add a perror option

### DIFF
--- a/stpandoc.sthlp
+++ b/stpandoc.sthlp
@@ -37,6 +37,7 @@ be saved{p_end}
 {synopt :{opt to(markup_format)}}specify the markup format of {it:targetfile}{p_end}
 {synopt :{opt path(path)}}specify the directory where the {bf:pandoc} executable is located{p_end}
 {synopt :{opt pargs(extra_args)}}specify the extra arguments for {bf:pandoc}{p_end}
+{synopt :{opt perr:or}}capture and display any {bf:pandoc} errors{p_end}
 {synoptline}
 {p2colreset}{...}
 {p 4 6 2}* {opt saving(targetfile)} is required.
@@ -72,6 +73,9 @@ be saved{p_end}
 
 {phang}
 {opt pargs(extra_args)} specifies the extra arguments for {bf:pandoc}.
+
+{phang}
+{opt perror} captures and displays any errors from {bf:pandoc}.
 
 {marker remarks}{...}
 {title:Remarks}


### PR DESCRIPTION
This updates the quoting on the call to the Pandoc executable, so that it will work with Windows paths that include spaces in them (like "program files").

This also adds a "perror" option to `stpandoc`.  If the user is having trouble specifying arguments to Pandoc correctly, using this option will capture Pandoc's error messages, and display them in Stata's Results window.